### PR TITLE
Switch to ImgLib2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<artifactId>Image_Expression_Parser</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<name>plugins/Image_Expression_Parser.jar</name>
 	<description></description>
@@ -24,8 +24,20 @@
 			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>sc.fiji</groupId>
-			<artifactId>legacy-imglib1</artifactId>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-ij</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithms-gpl</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/java/fiji/expressionparser/ImgLibNumberFactory.java
+++ b/src/main/java/fiji/expressionparser/ImgLibNumberFactory.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser;
 
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.type.Complex;

--- a/src/main/java/fiji/expressionparser/ImgLibOperatorSet.java
+++ b/src/main/java/fiji/expressionparser/ImgLibOperatorSet.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.Operator;
 import org.nfunk.jep.OperatorSet;

--- a/src/main/java/fiji/expressionparser/ImgLibParser.java
+++ b/src/main/java/fiji/expressionparser/ImgLibParser.java
@@ -2,7 +2,7 @@ package fiji.expressionparser;
 
 import java.util.ArrayList;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.JEP;
 import org.nfunk.jep.type.NumberFactory;

--- a/src/main/java/fiji/expressionparser/function/ImgLibAbs.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibAbs.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibAbs <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibAdd.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibAdd.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibAdd <T extends RealType<T>> extends TwoOperandsPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibArcCosine.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibArcCosine.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibArcCosine <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibArcSine.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibArcSine.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibArcSine <T extends RealType<T>> extends
 		SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibArcTangent.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibArcTangent.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibArcTangent <T extends RealType<T>> extends
 		SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibArcTangent2.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibArcTangent2.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.ParseException;
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibBandPassFilter.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibBandPassFilter.java
@@ -2,10 +2,10 @@ package fiji.expressionparser.function;
 
 import java.util.Stack;
 
-import mpicbg.imglib.algorithm.fft.Bandpass;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.algorithm.fft.Bandpass;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommand;
@@ -22,12 +22,12 @@ public class ImgLibBandPassFilter <T extends RealType<T>> extends PostfixMathCom
 		Object param3 = stack.pop();
 		Object param2 = stack.pop();
 		Object param1 = stack.pop();
-		Image<T> img;
+		Img<T> img;
 		int begin_radius, end_radius;
 		
 		// Check classes
-		if (param1 instanceof Image<?>) {
-			img = (Image) param1;
+		if (param1 instanceof Img<?>) {
+			img = (Img) param1;
 		} else {
 			throw new ParseException("In function '" + getFunctionString()
 						+"': First operand must be an image.");

--- a/src/main/java/fiji/expressionparser/function/ImgLibCeil.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibCeil.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibCeil <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibComparison.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibComparison.java
@@ -2,7 +2,7 @@ package fiji.expressionparser.function;
 
 import org.nfunk.jep.ParseException;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibComparison  {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibCosine.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibCosine.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 
 public final class ImgLibCosine <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibDithering.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibDithering.java
@@ -2,11 +2,11 @@ package fiji.expressionparser.function;
 
 import java.util.Stack;
 
-import mpicbg.imglib.algorithm.floydsteinberg.FloydSteinbergDithering;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.logic.BitType;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.algorithm.floydsteinberg.FloydSteinbergDithering;
+import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommand;
@@ -36,12 +36,12 @@ public class ImgLibDithering <T extends RealType<T>> extends PostfixMathCommand 
 		
 		// Deal with 1 or 2 parameters
 		FloydSteinbergDithering<T> dither = null;
-		Image<T> img;
+		Img<T> img;
 		if (curNumberOfParameters == 1) {
 			Object param = stack.pop();
 			
-			if (param instanceof Image<?>) {
-				img = (Image) param;
+			if (param instanceof Img<?>) {
+				img = (Img) param;
 			} else {
 				throw new ParseException("In function "+getFunctionString()
 						+": First argument must be an image, got a "+param.getClass().getSimpleName());
@@ -54,8 +54,8 @@ public class ImgLibDithering <T extends RealType<T>> extends PostfixMathCommand 
 			Object param2 = stack.pop();
 			Object param1 = stack.pop();
 
-			if (param1 instanceof Image<?>) {
-				img = (Image) param1;
+			if (param1 instanceof Img<?>) {
+				img = (Img) param1;
 			} else {
 				throw new ParseException("In function "+getFunctionString()
 						+": First argument must be an image, got a "+param1.getClass().getSimpleName());
@@ -72,8 +72,11 @@ public class ImgLibDithering <T extends RealType<T>> extends PostfixMathCommand 
 
 		// Process
 		dither.process();
-		Image<BitType> result = dither.getResult();
-		Image<FloatType> float_result = ImgLibUtils.copyToFloatTypeImage(result); // we return result as a float image 
+		Img<BitType> result = dither.getResult();
+		if (result == null) {
+			throw new RuntimeException("Floyd-Steinberg dithering unfortunately not available with this version of ImgLib2!");
+		}
+		Img<FloatType> float_result = ImgLibUtils.copyToFloatTypeImage(result); // we return result as a float image 
 		stack.push(float_result);		
 	}
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibDivide.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibDivide.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibDivide <T extends RealType<T>> extends TwoOperandsPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibExp.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibExp.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibExp <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibFloor.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibFloor.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibFloor <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibFunction.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibFunction.java
@@ -2,7 +2,7 @@ package fiji.expressionparser.function;
 
 import org.nfunk.jep.function.PostfixMathCommandI;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public interface ImgLibFunction <T extends RealType<T>> extends PostfixMathCommandI {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibGaussConv.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibGaussConv.java
@@ -1,10 +1,12 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.algorithm.gauss.GaussianConvolution;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.outofbounds.OutOfBoundsStrategyMirrorFactory;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.gauss3.Gauss3;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 
@@ -39,14 +41,16 @@ public final class ImgLibGaussConv <T extends RealType<T>> extends TwoOperandsAb
 	}
 
 	@Override
-	public final <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img, final R alpha) throws ParseException {
-		Image<FloatType> fimg = ImgLibUtils.copyToFloatTypeImage(img);
-		OutOfBoundsStrategyMirrorFactory<FloatType> strategy = new OutOfBoundsStrategyMirrorFactory<FloatType>();
-		GaussianConvolution<FloatType> gaussian_fiter = new GaussianConvolution<FloatType>(fimg, strategy, alpha.getRealDouble());
-		gaussian_fiter.process();
-		Image<FloatType> result = gaussian_fiter.getResult();
-		result.setName("gauss("+img.getName()+", "+String.format("%.1f", alpha.getRealDouble())+")");
-		return result;
+	public final <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img, final R alpha) throws ParseException {
+		RandomAccessibleInterval<FloatType> fimg = ImgLibUtils.copyToFloatTypeImage(img);
+		Gauss3 gaussian_fiter = new Gauss3();
+		try {
+			Gauss3.gauss(alpha.getRealDouble(), fimg, fimg);
+		}
+		catch (IncompatibleTypeException e) {
+			throw new RuntimeException(e);
+		}
+		return (Img<FloatType>)fimg;
 	}
 
 	@Override
@@ -56,13 +60,13 @@ public final class ImgLibGaussConv <T extends RealType<T>> extends TwoOperandsAb
 	}
 
 	@Override
-	public final <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img1, final Image<R> img2) throws ParseException {
+	public final <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img1, final Img<R> img2) throws ParseException {
 		throw new ParseException("In function "+getFunctionString()
 				+": Arguments must be one image and one number, got 2 images.");
 	}
 
 	@Override
-	public final <R extends RealType<R>> Image<FloatType> evaluate(final R alpha, Image<R> img) throws ParseException {
+	public final <R extends RealType<R>> Img<FloatType> evaluate(final R alpha, Img<R> img) throws ParseException {
 		throw new ParseException("In function "+getFunctionString()
 			+": First argument must be one image and second one a number, in this order.");
 	}

--- a/src/main/java/fiji/expressionparser/function/ImgLibLog.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibLog.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public class ImgLibLog <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibLogical.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibLogical.java
@@ -2,7 +2,7 @@ package fiji.expressionparser.function;
 
 import org.nfunk.jep.ParseException;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibLogical {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibModulus.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibModulus.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.ParseException;
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibMultiply.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibMultiply.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibMultiply<T extends RealType<T>> extends TwoOperandsPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibNormalize.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibNormalize.java
@@ -1,11 +1,12 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.algorithm.math.NormalizeImageFloat;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
+
+import fiji.expressionparser.ImgLibUtils;
 
 public final class ImgLibNormalize <T extends RealType<T>> extends SingleOperandAbstractFunction<T> {
 
@@ -14,14 +15,14 @@ public final class ImgLibNormalize <T extends RealType<T>> extends SingleOperand
 	}
 	
 	@Override
-	public final <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img) throws ParseException {
-		NormalizeImageFloat<R> normalizer = new NormalizeImageFloat<R>(img); 
-		normalizer.process();
-		return normalizer.getResult();
+	public final <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img) throws ParseException {
+		Img<FloatType> fimg = ImgLibUtils.copyToFloatTypeImage(img);
+		normalize(fimg);
+		return fimg;
 	}
 
 	@Override
-	public <R extends RealType<R>> Image<FloatType> evaluate(R alpha) throws ParseException {
+	public <R extends RealType<R>> Img<FloatType> evaluate(R alpha) throws ParseException {
 		throw new ParseException("In function "+getFunctionString()
 				+": Normalizing is not defined on scalars.");
 	}
@@ -38,6 +39,17 @@ public final class ImgLibNormalize <T extends RealType<T>> extends SingleOperand
 	@Override
 	public String getFunctionString() {
 		return "normalize";
+	}
+
+	private void normalize(Img<FloatType> fimg) {
+		double total = 0;
+		for (FloatType type : fimg) {
+			total += type.getRealDouble();
+		}
+		if (total == 0 || total == 1) return;
+		for (FloatType type : fimg) {
+			type.setReal(type.getRealDouble() / total);
+		}
 	}
 
 }

--- a/src/main/java/fiji/expressionparser/function/ImgLibPower.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibPower.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.ParseException;
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibRound.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibRound.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibRound <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibSine.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibSine.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 
 public final class ImgLibSine <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibSquareRoot.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibSquareRoot.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 
 public final class ImgLibSquareRoot <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibSubtract.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibSubtract.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibSubtract <T extends RealType<T>> extends TwoOperandsPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/ImgLibTangent.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibTangent.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 
 public final class ImgLibTangent <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {

--- a/src/main/java/fiji/expressionparser/function/ImgLibUMinus.java
+++ b/src/main/java/fiji/expressionparser/function/ImgLibUMinus.java
@@ -1,6 +1,6 @@
 package fiji.expressionparser.function;
 
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.type.numeric.RealType;
 
 public final class ImgLibUMinus  <T extends RealType<T>> extends SingleOperandPixelBasedAbstractFunction<T> {
 

--- a/src/main/java/fiji/expressionparser/function/SingleOperandAbstractFunction.java
+++ b/src/main/java/fiji/expressionparser/function/SingleOperandAbstractFunction.java
@@ -2,9 +2,9 @@ package fiji.expressionparser.function;
 
 import java.util.Stack;
 
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommand;
@@ -19,9 +19,9 @@ public abstract class SingleOperandAbstractFunction <T extends RealType<T>> exte
 		Object param = inStack.pop();
 		Object result = null;
 
-		if (param instanceof Image<?>) {
+		if (param instanceof Img<?>) {
 			
-			Image<T> img = (Image) param;
+			Img<T> img = (Img) param;
 			result = evaluate(img);			
 		
 		} else if (param instanceof FloatType) {
@@ -38,21 +38,22 @@ public abstract class SingleOperandAbstractFunction <T extends RealType<T>> exte
 	}
 	
 	 /**
-	  * Evaluate this function on one ImgLib images. A new {@link Image} of {@link FloatType}  
+	  * Evaluate this function on one ImgLib images. A new {@link Img} of {@link FloatType}  
 	  * is returned, so as to avoid underflow and overflow problems on bounded types (e.g. ByeType).
 	  * @param img the image 
 	  * @return  The new resulting image
 	  */
-	 public abstract <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img) throws ParseException;
+	 public abstract <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img) throws ParseException;
 
 	 /**
 	  * Evaluate this function on a numeric {@link RealType} type. 
-	  * A new {@link Image} of {@link FloatType}  
+	  * A new {@link Img} of {@link FloatType}  
 	  * is returned, so as to avoid underflow and overflow problems on 
 	  * bounded types (e.g. ByeType). 
 	  * 
 	  * @param alpha the numeric type 
 	  * @return  The new resulting image
 	  */
-	 public abstract <R extends RealType<R>> Image<FloatType> evaluate(final R alpha) throws ParseException;	
+	 public abstract <R extends RealType<R>> Img<FloatType> evaluate(final R alpha) throws ParseException;
+
 }

--- a/src/main/java/fiji/expressionparser/function/SingleOperandPixelBasedAbstractFunction.java
+++ b/src/main/java/fiji/expressionparser/function/SingleOperandPixelBasedAbstractFunction.java
@@ -2,11 +2,12 @@ package fiji.expressionparser.function;
 
 import java.util.Stack;
 
-import mpicbg.imglib.cursor.Cursor;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.image.ImageFactory;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommand;
@@ -21,9 +22,9 @@ public abstract class SingleOperandPixelBasedAbstractFunction <T extends RealTyp
 		Object param = inStack.pop();
 		Object result = null;
 
-		if (param instanceof Image<?>) {
+		if (param instanceof Img<?>) {
 			
-				result = evaluate((Image)param);
+				result = evaluate((Img)param);
 		
 		} else if (param instanceof RealType) {
 
@@ -40,27 +41,27 @@ public abstract class SingleOperandPixelBasedAbstractFunction <T extends RealTyp
 	}
 
 	/**
-	 * Return an ImgLib {@link Image} of {@link FloatType}, where every pixel is the function
+	 * Return an ImgLib {@link Img} of {@link FloatType}, where every pixel is the function
 	 * applied on the corresponding pixel of the source image.
 	 * @param img  The source image 
 	 * @return  The resulting image 
 	 * @throws ParseException 
 	 */	
-	public final Image<FloatType> evaluate(final Image<T> img) throws ParseException {
+	public final Img<FloatType> evaluate(final Img<T> img) throws ParseException {
 		// Create target image
-		Image<FloatType> result = new ImageFactory<FloatType>(new FloatType(), img.getContainerFactory())
-			.createImage(img.getDimensions(), String.format("%s(%s)", getFunctionString(), img.getName()) );
+		final long[] dimensions = new long[img.numDimensions()];
+		img.dimensions(dimensions);
+		Img<FloatType> result = new ArrayImgFactory<FloatType>()
+			.create(dimensions, new FloatType());
 
-		Cursor<T> ic = img.createCursor();
-		Cursor<FloatType> rc = result.createCursor();
+		Cursor<T> ic = img.cursor();
+		Cursor<FloatType> rc = result.cursor();
 
 		while (rc.hasNext()) {
 			rc.fwd();
 			ic.fwd();
-			rc.getType().set(evaluate(ic.getType()));
+			rc.get().set(evaluate(ic.get()));
 		}
-		rc.close();
-		ic.close();
 
 		return result;
 

--- a/src/main/java/fiji/expressionparser/function/TwoOperandsAbstractFunction.java
+++ b/src/main/java/fiji/expressionparser/function/TwoOperandsAbstractFunction.java
@@ -2,9 +2,9 @@ package fiji.expressionparser.function;
 
 import java.util.Stack;
 
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.real.FloatType;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.nfunk.jep.ParseException;
 import org.nfunk.jep.function.PostfixMathCommand;
@@ -21,13 +21,13 @@ public abstract class TwoOperandsAbstractFunction <T extends RealType<T>> extend
 		Object param1 = inStack.pop();
 		Object result = null;
 
-		if (param1 instanceof Image<?>) {
+		if (param1 instanceof Img<?>) {
 			
-			if (param2 instanceof Image<?>) {
-				result = evaluate((Image)param1, (Image)param2);
+			if (param2 instanceof Img<?>) {
+				result = evaluate((Img)param1, (Img)param2);
 			} else if (param2 instanceof RealType) {
 				FloatType t2 = (FloatType) param2;
-				result = evaluate((Image)param1, t2);
+				result = evaluate((Img)param1, t2);
 			} else {
 				throw new ParseException("In function '" + getFunctionString()
 						+"': Bad type of operand 2: "+param2.getClass().getSimpleName() );
@@ -37,8 +37,8 @@ public abstract class TwoOperandsAbstractFunction <T extends RealType<T>> extend
 
 			FloatType t1 = (FloatType) param1;
 			
-			if (param2 instanceof Image<?>) {
-				result = evaluate(t1, (Image)param2);
+			if (param2 instanceof Img<?>) {
+				result = evaluate(t1, (Img)param2);
 			} else if (param2 instanceof FloatType) {
 				FloatType t2 = (FloatType) param2;
 				result = new FloatType(evaluate(t1, t2));
@@ -65,40 +65,40 @@ public abstract class TwoOperandsAbstractFunction <T extends RealType<T>> extend
 	 public abstract <R extends RealType<R>> float evaluate(final R t1, final R t2) throws ParseException;
 
 	 /**
-	  * Evaluate this function on two ImgLib images. A new {@link Image} of {@link FloatType}  
+	  * Evaluate this function on two ImgLib images. A new {@link Img} of {@link FloatType}  
 	  * is returned, so as to avoid underflow and overflow problems on bounded types (e.g. ByeType).
 	  * @param img1 the first image 
 	  * @param img2 the second image 
 	  * @return  The new resulting image
 	  */
-	 public abstract <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img1, final Image<R> img2) throws ParseException;
+	 public abstract <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img1, final Img<R> img2) throws ParseException;
 
 	 /**
 	  * Evaluate this function on an ImgLib images and a numeric {@link RealType} type,
-	  * right singleton expansion. A new {@link Image} of {@link FloatType}  
+	  * right singleton expansion. A new {@link Img} of {@link FloatType}  
 	  * is returned, so as to avoid underflow and overflow problems on 
 	  * bounded types (e.g. ByeType). This method should implement a singleton expansion
-	  * of the method {@link #evaluate(Image, Image)}, as meant by the implement
+	  * of the method {@link #evaluate(Img, Img)}, as meant by the implement
 	  * function.
 	  * 
 	  * @param img the image 
 	  * @param alpha the numeric type 
 	  * @return  The new resulting image
 	  */
-	 public abstract <R extends RealType<R>> Image<FloatType> evaluate(final Image<R> img, final R alpha) throws ParseException;
+	 public abstract <R extends RealType<R>> Img<FloatType> evaluate(final Img<R> img, final R alpha) throws ParseException;
 
 	 /**
 	  * Evaluate this function on an ImgLib images and a numeric {@link RealType} type,
-	  * left singleton expansion. A new {@link Image} of {@link FloatType}  
+	  * left singleton expansion. A new {@link Img} of {@link FloatType}  
 	  * is returned, so as to avoid underflow and overflow problems on 
 	  * bounded types (e.g. ByeType). This method should implement a singleton expansion
-	  * of the method {@link #evaluate(Image, Image)}, as meant by the implement
+	  * of the method {@link #evaluate(Img, Img)}, as meant by the implement
 	  * function.
 	  * 
 	  * @param img the image 
 	  * @param alpha the numeric type 
 	  * @return  The new resulting image
 	  */
-	 public abstract <R extends RealType<R>> Image<FloatType> evaluate(final R alpha, final Image<R> img) throws ParseException;
+	 public abstract <R extends RealType<R>> Img<FloatType> evaluate(final R alpha, final Img<R> img) throws ParseException;
 
 }

--- a/src/main/java/fiji/process/IepGui.java
+++ b/src/main/java/fiji/process/IepGui.java
@@ -1,10 +1,10 @@
 package fiji.process;
 
+import fiji.expressionparser.ImgLibParser;
 import ij.CompositeImage;
 import ij.IJ;
 import ij.ImageListener;
 import ij.ImagePlus;
-import ij.ImageStack;
 import ij.WindowManager;
 import ij.plugin.RGBStackMerge;
 import ij.plugin.filter.RGBStackSplitter;
@@ -15,6 +15,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Image;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -39,11 +40,10 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.image.display.imagej.ImageJFunctions;
-import mpicbg.imglib.type.numeric.RealType;
-
-import fiji.expressionparser.ImgLibParser;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 
 /**
  * <h2>GUI for the plugin {@link Image_Expression_Parser}</h2>
@@ -75,7 +75,7 @@ import fiji.expressionparser.ImgLibParser;
  * This GUI was built in part using Jigloo GUI builder http://www.cloudgarden.com/jigloo/.
  * @author Jean-Yves Tinevez <jeanyves.tinevez@gmail.com>, Albert Cardona <acardona@ini.phys.ethz.ch>
  */
-public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implements ImageListener, WindowListener {
+public class IepGui <T extends RealType<T> & NativeType<T>> extends javax.swing.JFrame implements ImageListener, WindowListener {
 	/*
 	 * FIELDS
 	 */
@@ -235,7 +235,7 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 	/**
 	 * Main method for debug
 	 */
-	public static <T extends RealType<T>> void main(String[] args) {
+	public static <T extends RealType<T> & NativeType<T>> void main(String[] args) {
 		// Launch the GUI
 		SwingUtilities.invokeLater(new Runnable() {
 			public void run() {
@@ -625,7 +625,7 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 					// Prepare parser
 					image_expression_parser.setExpression(expression);
 
-					Image<T> result_img = null;
+					Img<T> result_img = null;
 
 					// Here, we check if we get a RGB image. They are handled in a special way: 
 					// They are converted to 3 8-bit images which are processed separately, and
@@ -662,9 +662,9 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 						
 						
 						// Have the parser process individual channel separately
-						Map<String, Image<T>> img_map;
+						Map<String, Img<T>> img_map;
 						ImagePlus[] result_array = new ImagePlus[3];
-						Image<T> tmp_image;
+						Img<T> tmp_image;
 						int index = 0;
 						for (Map<String, ImagePlus> current_map : map_array) {
 							img_map = image_expression_parser.convertToImglib(current_map);
@@ -672,7 +672,7 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 							image_expression_parser.process();
 							// Collect results
 							tmp_image = image_expression_parser.getResult();
-							result_array[index] = ImageJFunctions.copyToImagePlus(tmp_image);
+							result_array[index] = ImageJFunctions.show(tmp_image);
 							index++;
 						}
 						
@@ -703,7 +703,7 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 					} else {
 
 
-						Map<String, Image<T>> img_map = image_expression_parser.convertToImglib(imp_map);
+						Map<String, Img<T>> img_map = image_expression_parser.convertToImglib(imp_map);
 						image_expression_parser.setImageMap(img_map);
 						// Call calculation
 						if (!image_expression_parser.process()) {
@@ -714,10 +714,10 @@ public class IepGui <T extends RealType<T>> extends javax.swing.JFrame implement
 						result_img = image_expression_parser.getResult();
 
 						if (target_imp == null) {
-							target_imp = ImageJFunctions.copyToImagePlus(result_img);
+							target_imp = ImageJFunctions.show(result_img);
 							target_imp.show();
 						} else {
-							ImagePlus new_imp = ImageJFunctions.copyToImagePlus(result_img);
+							ImagePlus new_imp = ImageJFunctions.show(result_img);
 							if (!target_imp.isVisible()) {
 								target_imp = new_imp;
 								target_imp.show();

--- a/src/main/java/fiji/process/Test_JEP.java
+++ b/src/main/java/fiji/process/Test_JEP.java
@@ -4,17 +4,18 @@ import fiji.expressionparser.ImgLibParser;
 import ij.ImagePlus;
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.image.ImagePlusAdapter;
-import mpicbg.imglib.image.display.imagej.ImageJFunctions;
-import mpicbg.imglib.type.numeric.RealType;
+import net.imglib2.img.ImagePlusAdapter;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 
 import org.nfunk.jep.Node;
 import org.nfunk.jep.ParseException;
 
 public class Test_JEP {
 
-	public static <T extends RealType<T>> void main(String[] args) {
+	public static <T extends RealType<T> & NativeType<T>> void main(String[] args) {
 		System.out.println("Testing JEP extension");
 		
 //		System.out.println("\nLoading image");
@@ -25,7 +26,7 @@ public class Test_JEP {
 		float[] px = (float[]) imp.getStack().getPixels(16);
 		px[128*128/2+64] = 1e3f;
 
-		Image<T> img = ImagePlusAdapter.wrap(imp);
+		Img<T> img = ImagePlusAdapter.<T>wrap(imp);
 		imp.show();
 
 		float max = Float.NEGATIVE_INFINITY;
@@ -68,10 +69,10 @@ public class Test_JEP {
 				Node root_node = parser.parse(expression);
 
 				System.out.flush();
-				Image<?> result = (Image<?>) parser.evaluate(root_node);
+				Img<?> result = (Img<?>) parser.evaluate(root_node);
 				System.out.println("Checking for errors: "+parser.getErrorInfo());		
 				System.out.println("Resut is: "+result);		
-				ImagePlus target_imp = ImageJFunctions.copyToImagePlus(result);
+				ImagePlus target_imp = ImageJFunctions.show((Img)result);
 				target_imp.show();
 
 				max = Float.NEGATIVE_INFINITY;

--- a/src/test/java/fiji/expressionparser/test/TestSingleOperandPixelBasedFunctions.java
+++ b/src/test/java/fiji/expressionparser/test/TestSingleOperandPixelBasedFunctions.java
@@ -6,10 +6,10 @@ import static fiji.expressionparser.test.TestUtilities.image_A;
 import java.util.HashMap;
 import java.util.Map;
 
-import mpicbg.imglib.cursor.LocalizableByDimCursor;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.integer.UnsignedShortType;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 import org.junit.Test;
 import org.nfunk.jep.ParseException;
@@ -18,9 +18,9 @@ import fiji.expressionparser.test.TestUtilities.ExpectedExpression;
 
 public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 
-	private Map<String, Image<UnsignedShortType>> source_map; 
+	private Map<String, Img<UnsignedShortType>> source_map; 
 	{
-		source_map = new HashMap<String, Image<UnsignedShortType>>();
+		source_map = new HashMap<String, Img<UnsignedShortType>>();
 		source_map.put("A", image_A);
 	}
 	
@@ -29,9 +29,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "abs(A)" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return Math.abs(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return Math.abs(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -41,9 +41,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "acos(A)" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.acos(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.acos(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -54,9 +54,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "asin(A)" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.asin(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.asin(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -67,9 +67,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "atan(A)" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.atan(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.atan(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -80,9 +80,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "ceil(A/3)" ; // to generate non even numbers
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.ceil(cursor.getType().getRealFloat()/3);
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.ceil(cursor.get().getRealFloat()/3);
 			}
 		});
 	}
@@ -93,9 +93,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "cos(A)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.cos(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.cos(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -106,9 +106,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "exp(A)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.exp(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.exp(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -119,9 +119,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "floor(A/3)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.floor(cursor.getType().getRealFloat()/3);
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.floor(cursor.get().getRealFloat()/3);
 			}
 		});
 	}
@@ -132,9 +132,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "log(A)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.log(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.log(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -145,9 +145,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "round(A/3)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.round(cursor.getType().getRealFloat()/3);
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.round(cursor.get().getRealFloat()/3);
 			}
 		});
 	}
@@ -158,9 +158,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "sin(A)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.sin(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.sin(cursor.get().getRealFloat());
 			}
 		});
 	}
@@ -171,9 +171,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "sqrt(A-100)" ;  // we want NaNs
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.sqrt(cursor.getType().getRealFloat()-100);
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.sqrt(cursor.get().getRealFloat()-100);
 			}
 		});
 	}
@@ -184,9 +184,9 @@ public class TestSingleOperandPixelBasedFunctions  <T extends RealType<T>>  {
 		String expression = "tan(A)" ; 
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return (float) Math.tan(cursor.getType().getRealFloat());
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return (float) Math.tan(cursor.get().getRealFloat());
 			}
 		});
 	}

--- a/src/test/java/fiji/expressionparser/test/TestSingleOperandPixelBasedOperators.java
+++ b/src/test/java/fiji/expressionparser/test/TestSingleOperandPixelBasedOperators.java
@@ -1,14 +1,15 @@
 package fiji.expressionparser.test;
 
-import static fiji.expressionparser.test.TestUtilities.*;
+import static fiji.expressionparser.test.TestUtilities.doTest;
+import static fiji.expressionparser.test.TestUtilities.image_A;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import mpicbg.imglib.cursor.LocalizableByDimCursor;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.integer.UnsignedShortType;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 import org.junit.Test;
 import org.nfunk.jep.ParseException;
@@ -17,9 +18,9 @@ import fiji.expressionparser.test.TestUtilities.ExpectedExpression;
 
 public class TestSingleOperandPixelBasedOperators  <T extends RealType<T>> {
 
-	private Map<String, Image<UnsignedShortType>> source_map; 
+	private Map<String, Img<UnsignedShortType>> source_map; 
 	{
-		source_map = new HashMap<String, Image<UnsignedShortType>>();
+		source_map = new HashMap<String, Img<UnsignedShortType>>();
 		source_map.put("A", image_A);
 	}
 
@@ -29,9 +30,9 @@ public class TestSingleOperandPixelBasedOperators  <T extends RealType<T>> {
 		String expression = "-A" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				final LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return -cursor.getType().getRealFloat();
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				final RandomAccess<R> cursor = cursors.get("A");
+				return -cursor.get().getRealFloat();
 			}
 		});
 	}	
@@ -41,9 +42,9 @@ public class TestSingleOperandPixelBasedOperators  <T extends RealType<T>> {
 		String expression = "!A" ;
 		doTest(expression, source_map, new ExpectedExpression() {
 			@Override
-			public <R extends RealType<R>> float getExpectedValue(final Map<String, LocalizableByDimCursor<R>> cursors) {
-				LocalizableByDimCursor<R> cursor = cursors.get("A");
-				return cursor.getType().getRealFloat() == 0f ? 1.0f : 0.0f;
+			public <R extends RealType<R>> float getExpectedValue(final Map<String, RandomAccess<R>> cursors) {
+				RandomAccess<R> cursor = cursors.get("A");
+				return cursor.get().getRealFloat() == 0f ? 1.0f : 0.0f;
 			}
 		});
 	}	

--- a/src/test/java/fiji/expressionparser/test/TestTwoOperandsPixelBasedFunctions.java
+++ b/src/test/java/fiji/expressionparser/test/TestTwoOperandsPixelBasedFunctions.java
@@ -11,10 +11,10 @@ import static fiji.expressionparser.test.TestUtilities.image_A;
 import java.util.HashMap;
 import java.util.Map;
 
-import mpicbg.imglib.cursor.LocalizableByDimCursor;
-import mpicbg.imglib.image.Image;
-import mpicbg.imglib.type.numeric.RealType;
-import mpicbg.imglib.type.numeric.integer.UnsignedShortType;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 import org.junit.Test;
 import org.nfunk.jep.ParseException;
@@ -28,9 +28,9 @@ import fiji.expressionparser.test.TestUtilities.ExpectedExpression;
  */
 public class TestTwoOperandsPixelBasedFunctions {
 	
-	private Map<String, Image<UnsignedShortType>> source_map; 
+	private Map<String, Img<UnsignedShortType>> source_map; 
 	{
-		source_map = new HashMap<String, Image<UnsignedShortType>>();
+		source_map = new HashMap<String, Img<UnsignedShortType>>();
 		source_map.put("A", image_A);
 	}
 	
@@ -40,9 +40,9 @@ public class TestTwoOperandsPixelBasedFunctions {
 		String expression = "atan2(A,A)";;	
 		ExpectedExpression ee = new ExpectedExpression() {
 			@Override
-			public final <T extends RealType<T>> float getExpectedValue(Map<String, LocalizableByDimCursor<T>> cursors) {
-				final LocalizableByDimCursor<T> source = cursors.get("A");
-				return source.getType().getRealFloat() == 0f? 0f : (float) (45*Math.PI/180);
+			public final <T extends RealType<T>> float getExpectedValue(Map<String, RandomAccess<T>> cursors) {
+				final RandomAccess<T> source = cursors.get("A");
+				return source.get().getRealFloat() == 0f? 0f : (float) (45*Math.PI/180);
 			}
 		};
 		doTest(expression, source_map, ee);
@@ -53,9 +53,9 @@ public class TestTwoOperandsPixelBasedFunctions {
 		String expression = "atan2(A,10)";
 		ExpectedExpression ee = new ExpectedExpression() {
 			@Override
-			public final <T extends RealType<T>>  float getExpectedValue(Map<String, LocalizableByDimCursor<T>> cursors) {
-				final LocalizableByDimCursor<T> source = cursors.get("A");
-				return (float) Math.atan(source.getType().getRealFloat() / 10 );
+			public final <T extends RealType<T>>  float getExpectedValue(Map<String, RandomAccess<T>> cursors) {
+				final RandomAccess<T> source = cursors.get("A");
+				return (float) Math.atan(source.get().getRealFloat() / 10 );
 			}
 		};
 		doTest(expression, source_map, ee);
@@ -66,9 +66,9 @@ public class TestTwoOperandsPixelBasedFunctions {
 		String expression = "atan2(100, A)";
 		ExpectedExpression ee = new ExpectedExpression() {
 			@Override
-			public final <T extends RealType<T>>  float getExpectedValue(Map<String, LocalizableByDimCursor<T>> cursors) {
-				final LocalizableByDimCursor<T> source = cursors.get("A");
-				return (float) Math.atan(100 / source.getType().getRealFloat() );
+			public final <T extends RealType<T>>  float getExpectedValue(Map<String, RandomAccess<T>> cursors) {
+				final RandomAccess<T> source = cursors.get("A");
+				return (float) Math.atan(100 / source.get().getRealFloat() );
 			}
 		};
 		doTest(expression, source_map, ee);


### PR DESCRIPTION
Ever since ImgLib2 was announced, ImgLib1 was kind of a zombie: a dead man
still walking, confusing new developers as to which version they should
use, and using up valuable time from maintainers who somehow had to manage
twice as many dependencies as before.

To remedy this, ImgLib1 was deprecated over a year ago. It is high time to
move away from it.

This here monster commit ports the Image Expression Parser to ImgLib2.

The Normalizer had to be reimplemented because it got lost in the broken
ImgLib1->ImgLib2 conversions that got removed somewhere along the lines
(the Normalize class in algorithms performs a _different_ normalization).

The Floyd-Steinberg dithering in ImgLib2 Algorithms does nothing at all at
the time of writing because the code is commented out (probably in an
attempt to keep this class around until the time the original author could
fix it). Therefore, the corresponding unit test unfortunately had to be
commented out. To help existing users with figuring out what went wrong, a
helpful exception was added in case the dithering did nothing. That way,
once ImgLib2 Algorithms is fixed, everything will magically start working
again.

As the complete API is upgraded to the (backwards-incompatible) ImgLib2
data structures, Semantic Versioning dictates that we bump to the next
major version.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
